### PR TITLE
SS-7338 Refactor param/export accordion component to behave like on platform

### DIFF
--- a/src/components/shapediver/ui/ParametersAndExportsAccordionComponent.module.css
+++ b/src/components/shapediver/ui/ParametersAndExportsAccordionComponent.module.css
@@ -2,6 +2,11 @@
 	display: flex;
 	flex-direction: column;
 	max-height: 100%;
+
+	:global(.mantine-Accordion-content) {
+		padding-left: 0.5rem;
+		padding-right: 0.5rem;
+	}
 }
 
 .scrollArea {

--- a/src/components/shapediver/ui/ParametersAndExportsAccordionComponent.tsx
+++ b/src/components/shapediver/ui/ParametersAndExportsAccordionComponent.tsx
@@ -1,5 +1,5 @@
 import React, { JSX } from "react";
-import { Accordion, Button, Divider, Loader, ScrollArea } from "@mantine/core";
+import { Accordion, Button, Loader, Paper, ScrollArea } from "@mantine/core";
 import { getExportComponent, getParameterComponent } from "types/components/shapediver/componentTypes";
 import { PropsParameter } from "types/components/shapediver/propsParameter";
 import { PropsExport } from "types/components/shapediver/propsExport";
@@ -17,14 +17,14 @@ import classes from "./ParametersAndExportsAccordionComponent.module.css";
 interface Props {
 	parameters?: PropsParameter[],
 	exports?: PropsExport[],
-	/** 
-	 * Name of group to use for parameters and exports which are not assigned to a group. 
+	/**
+	 * Name of group to use for parameters and exports which are not assigned to a group.
 	 * Leave this empty to not display such parameters and exports inside of an accordion.
 	 */
 	defaultGroupName?: string,
 	/**
-	 * Set this to true to avoid groups containing a single parameter or export component. 
-	 * In case this is not set or false, parameters and exports of groups with a single 
+	 * Set this to true to avoid groups containing a single parameter or export component.
+	 * In case this is not set or false, parameters and exports of groups with a single
 	 * compnent will be displayed without using an accordion.
 	 */
 	avoidSingleComponentGroups?: boolean,
@@ -35,7 +35,7 @@ export default function ParametersAndExportsAccordionComponent({ parameters, exp
 	const sortedParamsAndExports = useSortedParametersAndExports(parameters, exports);
 	avoidSingleComponentGroups = false;
 	const acceptRejectMode = sortedParamsAndExports.some(p => p.parameter?.acceptRejectMode);
-	
+
 	// check if there are parameter changes to be confirmed
 	const parameterChanges = useParameterChanges(parameters || []);
 	const disableChangeControls = parameterChanges.length === 0 ||
@@ -75,7 +75,7 @@ export default function ParametersAndExportsAccordionComponent({ parameters, exp
 			groupIds[group.id] = elementGroups.length - 1;
 		}
 		const groupId = group ? groupIds[group.id] : elementGroups.length - 1;
-	
+
 		if (param.parameter) {
 			// Get the element for the parameter and add it to the group
 			const ParameterComponent = getParameterComponent(param.definition);
@@ -138,12 +138,14 @@ export default function ParametersAndExportsAccordionComponent({ parameters, exp
 	// loop through the created elementGroups to add them
 	let accordionItems: JSX.Element[] = [];
 	for (const g of elementGroups) {
-	
-		// add dividers between the elements
+
 		const groupElements: JSX.Element[] = [];
-		g.elements.forEach((element, index) => {
-			groupElements.push(element);
-			if (index !== g.elements.length - 1) groupElements.push(<Divider key={element.key + "_divider"} my="sm" />);
+		g.elements.forEach((element) => {
+			groupElements.push(
+				<Paper withBorder radius="md" shadow="m" my="xs" py="md" px="xs">
+					{ element }
+				</Paper>
+			);
 		});
 
 		if (g.group && (!avoidSingleComponentGroups || g.elements.length > 1)) {
@@ -175,7 +177,7 @@ export default function ParametersAndExportsAccordionComponent({ parameters, exp
 			</Accordion>
 		);
 	}
-	
+
 	return <>
 		{ acceptRejectElement }
 		<ScrollArea.Autosize className={classes.scrollArea}>

--- a/src/components/ui/ModelSelect.tsx
+++ b/src/components/ui/ModelSelect.tsx
@@ -50,7 +50,7 @@ export default function ModelSelect() {
 
 	// get parameter and export props for all sessions
 	const parameterProps = useSessionPropsParameter(sessionIds);
-	const exportProps = useSessionPropsExport(sessionIds);
+	//const exportProps = useSessionPropsExport(sessionIds);
 
 	const tabs = selectedModels.length === 0 ? <></> : <Tabs defaultValue={selectedModels[0].slug} className={classes.tabs}>
 		<Tabs.List>
@@ -63,7 +63,7 @@ export default function ModelSelect() {
 				<ParametersAndExportsAccordionTab key={model.slug} value={model.slug} pt={isMobile ? "" : "xs"}>
 					<ParametersAndExportsAccordionComponent
 						parameters={parameterProps.filter(p => p.sessionId === model.slug)}
-						exports={exportProps.filter(p => p.sessionId === model.slug)}
+						//exports={exportProps.filter(p => p.sessionId === model.slug)}
 					/>
 				</ParametersAndExportsAccordionTab>
 			)

--- a/src/hooks/useSortedParametersAndExports.ts
+++ b/src/hooks/useSortedParametersAndExports.ts
@@ -35,7 +35,10 @@ export function useSortedParametersAndExports(parameters?: PropsParameter[], exp
 	}));
 
 	// sort the parameters
-	sortedParamsAndExports.sort((a, b) => (a.definition.order || Infinity) - (b.definition.order || Infinity));
+	sortedParamsAndExports.sort((a, b) => 
+		(typeof a.definition.order === "number" ? a.definition.order : Infinity) 
+		- (typeof b.definition.order === "number" ? b.definition.order : Infinity)
+	);
 
 	return sortedParamsAndExports;
 }

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -42,7 +42,7 @@ Check out the source code for this example <a href="https://github.com/shapedive
 						title="Model View Page"
 						description="This example opens a session with a ShapeDiver model, displays it in a viewport, and creates two tabs of components representing
 the parameters and exports defined by the model. All components are easily customizable."
-						btnText="On to the View Page!"
+						btnText="Open example"
 						btnLink="/view"
 						imageSrc="https://img2.storyblok.com/1280x0/filters:format(webp)/f/92524/2048x1481/81a30bd9de/0202.png"
 						imageAlt="Under Construction"
@@ -53,7 +53,7 @@ the parameters and exports defined by the model. All components are easily custo
 						description="This example displays a single viewport into which sessions with multiple ShapeDiver models can be loaded at once.
 The settings of the model which is selected first are used to configure the viewport (camera, controls, etc).
 Parameter and export controls are shown for all selected models."
-						btnText="On to the Model Select Page!"
+						btnText="Open example"
 						btnLink="/modelSelect"
 						imageSrc="https://img2.storyblok.com/1280x0/filters:format(webp)/f/92524/2048x1481/81a30bd9de/0202.png"
 						imageAlt="Under Construction"
@@ -62,7 +62,7 @@ Parameter and export controls are shown for all selected models."
 					<ModelCard
 						title="Multiple Viewports and Models Page"
 						description="This example displays multiple viewports and models."
-						btnText="On to the Multiple Viewports and Models page!"
+						btnText="Open example"
 						btnLink="/multipleViewport"
 						imageSrc="https://img2.storyblok.com/1280x0/filters:format(webp)/f/92524/2048x1481/81a30bd9de/0202.png"
 						imageAlt="Under Construction"
@@ -71,7 +71,7 @@ Parameter and export controls are shown for all selected models."
 					<ModelCard
 						title="Custom UI Page"
 						description="This example shows how to use Grasshopper to influence the parameter panel (show/hide parameters, add custom parameters)."
-						btnText="On to the Custom UI page!"
+						btnText="Open example"
 						btnLink="/customui"
 						imageSrc="https://img2.storyblok.com/1280x0/filters:format(webp)/f/92524/2048x1481/81a30bd9de/0202.png"
 						imageAlt="Under Construction"

--- a/src/tickets.ts
+++ b/src/tickets.ts
@@ -13,7 +13,7 @@ export const ShapeDiverExampleModels : {
 	},
 	"AR Cube": {
 		slug: "react-ar-cube",
-		ticket: "f447479a164edd5eaff704f15bc181404f35b949d399e4428c3328846b26a3649bb846228eeda0d93dcd4395232c6af56fcbb48c576cfddcdbc8c5137c71e0a26f776309a0f539a6cfa2efbc2851f953f0abf283365ade3afbb907dadda0b8b147e3579d012fac-fdc1e8ec7c10b9bdaf652491cf5524c5",
+		ticket: "3b5fbadd8b20ede476feeba00fa2aaebde1e3d9500b6ff87c30da56afd9fac39a435d0cb08de109c9857f7a626a2a275b9902678ead17b9596119142562aa75bca8efa7cbe646577811c9b0e0c7a30f91f06a81ec50fe63cb7bc3bce8c7fd625fd20f14cd3273f-5ac2798236496b0fd3df167bc1f00a76",
 		modelViewUrl: "https://sdr7euc1.eu-central-1.shapediver.com"
 	},
 	"Naming scheme demo": {
@@ -41,4 +41,9 @@ export const ShapeDiverExampleModels : {
 		ticket: "0be61d6f551424911dc15ca992c76cf2eab5c32aceccfbde18beb98bc98c769409c03c6e41dcac36051ee2fd066bb21e7cde6567f86287997e6cf58185fc88c8116b8058bba83e4528a2eb6cc8bb78e339a618f489696ac887ea2a762c331e7256ebbcd52a0052-e5245082baf9f79145f9b6bdc2fcf867",
 		modelViewUrl: "https://sdr7euc1.eu-central-1.shapediver.com"
 	},
+	"AccordionTest": {
+		slug: "arrs-improved-materials-r6-8",
+		ticket: "b613bb9d71824b0199c4699836d446b7cac7d672db7d504f94d78edf8c15c96b573cbdf38a46afff861b0463aa1be5fa6c49774e9df8d1a0272e682a63cd6146a95ab055beff8dc8d8fa55988062718aa37fdbf48344300ae44b2cab5740f97a0daab943200aa3-3f23fbdbf5e6da2c0948caa7c60c45e9",
+		modelViewUrl: "https://sdr7euc1.eu-central-1.shapediver.com"
+	}
 };


### PR DESCRIPTION
https://shapediver.atlassian.net/browse/SS-7338

@mathieu-shapediver I refactored the parameter/export accordion to behave like the parameter component on the platform. There are two optional settings `defaultGroupName` and `avoidSingleComponentGroups`. The CSS and layout needs to be fixed/improved. 

Examples for testing (Go to "Select Page"): 

## model "AccordionTest" 
Mixture of groups and single parameters.
Model on [platform](https://www.shapediver.com/app/m/arrs-improved-materials-r6-8) for comparison.
<img width="628" alt="image" src="https://github.com/shapediver/ShapeDiverReactExample/assets/8183687/d2a0fbd1-f69d-4eb0-8539-d0f0838b35ab">

## model "Ring"
No groups. 
<img width="620" alt="image" src="https://github.com/shapediver/ShapeDiverReactExample/assets/8183687/b9154eb3-c158-4e22-9ecf-0369f1a2b677">

## model "AR Cube"
Mixture of groups and single parameters.
<img width="624" alt="image" src="https://github.com/shapediver/ShapeDiverReactExample/assets/8183687/2b789cee-78fe-453e-b7e1-f796810c5d90">
