### PR TITLE
SS-6250: Material hook (custom material changes)

### DIFF
--- a/src/hooks/useOutputMaterial.ts
+++ b/src/hooks/useOutputMaterial.ts
@@ -65,6 +65,7 @@ export function useOutputMaterial(sessionId: string, outputIdOrName: string, mat
 				const material = new MaterialStandardData(materialProps);
 				data.material = material;
 			}
+			data.updateVersion();
 		});
 
 		node.updateVersion();

--- a/src/hooks/useOutputMaterial.ts
+++ b/src/hooks/useOutputMaterial.ts
@@ -74,6 +74,7 @@ export function useOutputMaterial(sessionId: string, outputIdOrName: string, mat
 			MaterialClassType = MaterialStandardData;
 		}
 
+		let newMaterial: MaterialStandardData | MaterialSpecularGlossinessData | MaterialUnlitData | MaterialGemData | undefined;
 		// update all geometry materials
 		geometryData.forEach(data => {
 			if (data.material && data.material instanceof MaterialClassType) {
@@ -84,9 +85,12 @@ export function useOutputMaterial(sessionId: string, outputIdOrName: string, mat
 
 				data.material.updateVersion();
 			} else {
+				// if we didn't already create a new material, do it now
+				if (!newMaterial)
+					newMaterial = new MaterialClassType(materialProps);
+
 				// no material found: define new material
-				const material = new MaterialClassType(materialProps);
-				data.material = material;
+				data.material = newMaterial;
 			}
 			data.updateVersion();
 		});

--- a/src/hooks/useOutputNode.ts
+++ b/src/hooks/useOutputNode.ts
@@ -3,11 +3,14 @@ import { useCallback, useEffect, useId, useState } from "react";
 import { useOutputUpdateCallback } from "./useOutputUpdateCallback";
 import { useOutput } from "./useOutput";
 
+/**
+ * 
+ */
 type UpdateCallback = (newNode?: ITreeNode, oldNode?: ITreeNode) => Promise<void> | void;
 
 /**
  * Hook providing access to outputs by id or name, 
- * allowing to register a callback for updates, 
+ * allowing to register a callback for updates of the output, 
  * and providing the scene tree node of the output.
  * 
  * @see https://viewer.shapediver.com/v3/latest/api/interfaces/IOutputApi.html
@@ -16,6 +19,10 @@ type UpdateCallback = (newNode?: ITreeNode, oldNode?: ITreeNode) => Promise<void
  * 
  * @param sessionId 
  * @param outputIdOrName 
+ * @param callback Optional callback which will be called on update of the output node.
+ *                 The callback will be called with the new and old node. 
+ * 			   	   The very first call will not include an old node.
+ *                 The very last call will not include a new node.
  * @returns 
  */
 export function useOutputNode(sessionId: string, outputIdOrName: string, callback?: UpdateCallback) : {
@@ -36,8 +43,6 @@ export function useOutputNode(sessionId: string, outputIdOrName: string, callbac
 
 	// combine the optional user-defined callback with setting the current node
 	const cb = useCallback( (node?: ITreeNode, oldnode?: ITreeNode) => {
-		// TODO remove this
-		console.debug("node", node, "oldnode", oldnode);
 		setNode(node);
 		
 		return callback && callback(node, oldnode);

--- a/src/hooks/useOutputNode.ts
+++ b/src/hooks/useOutputNode.ts
@@ -35,24 +35,25 @@ export function useOutputNode(sessionId: string, outputIdOrName: string, callbac
 	const [node, setNode] = useState<ITreeNode | undefined>(outputApi?.node);
 
 	// combine the optional user-defined callback with setting the current node
-	const cb = useCallback( (node?: ITreeNode) => {
+	const cb = useCallback( (node?: ITreeNode, oldnode?: ITreeNode) => {
+		// TODO remove this
+		console.debug("node", node, "oldnode", oldnode);
 		setNode(node);
 		
-		return callback && callback(node);
+		return callback && callback(node, oldnode);
 	}, [callback] );
 
 	const callbackId = useId();
 	useOutputUpdateCallback(sessionId, outputIdOrName, callbackId, cb);
 	
 	// use an effect to set the initial node
-	const [ initialNodeSet, setInitialNode ] = useState(false);
 	useEffect(() => {
-		if (!initialNodeSet && outputApi?.node) {
-			if (node !== outputApi.node)
-				setNode(outputApi.node);
-			setInitialNode(true);
-		}
-	}, [outputApi, initialNodeSet]);
+		cb(outputApi?.node);
+		
+		return () => {
+			cb(undefined, outputApi?.node);
+		};
+	}, [outputApi]);
 
 	return {
 		outputApi,

--- a/src/pages/ViewPage.tsx
+++ b/src/pages/ViewPage.tsx
@@ -150,7 +150,7 @@ export default function ViewPage() {
 	const myParameterProps = useSessionPropsParameter("mysession");
 
 	// apply the custom material
-	useOutputMaterial(sessionId, outputNameOrId, materialProperties, MaterialType.Unlit);
+	useOutputMaterial(sessionId, outputNameOrId, materialProperties, MaterialType.Standard);
 	
 	/////	
 	// END - Example on how to apply a custom material to an output

--- a/src/pages/ViewPage.tsx
+++ b/src/pages/ViewPage.tsx
@@ -63,29 +63,35 @@ export default function ViewPage() {
 	/////	
 	const outputNameOrId = "Shelf";
 
+	const enum PARAMETER_NAMES {
+		COLOR = "color",
+		MAP = "map",
+		ROUGHNESS = "roughness"
+	}
+
 	// create parameter definitions for the custom material
-	const definitions: { [key: string]: IGenericParameterDefinition } = {
-		color: {
+	const definitions: IGenericParameterDefinition[] = [
+		{
 			definition: {
-				id: "colorParam",
+				id: PARAMETER_NAMES.COLOR,
 				name: "Custom color",
 				defval: "0x0d44f0ff",
 				type: "Color",
 				hidden: false
 			}
 		},
-		map: {
+		{
 			definition: {
-				id: "mapParam",
+				id: PARAMETER_NAMES.MAP,
 				name: "Custom map",
 				defval: "",
 				type: "String",
 				hidden: false
 			}
 		},
-		roughness: {
+		{
 			definition: {
-				id: "roughnessParam",
+				id: PARAMETER_NAMES.ROUGHNESS,
 				name: "Custom roughness",
 				defval: "0",
 				type: PARAMETER_TYPE.FLOAT,
@@ -93,32 +99,33 @@ export default function ViewPage() {
 				max: 1,
 				decimalplaces: 4,
 				hidden: false
+
 			}
 		}
-	};
+	];
 	
 	// define a generic parameter which influences a custom material definition
-	const [materialParameters] = useState<IGenericParameterDefinition[]>(Object.values(definitions));
+	const [materialParameters] = useState<IGenericParameterDefinition[]>(definitions);
 
 	const [materialProperties, setMaterialProperties] = useState<IMaterialStandardDataProperties>({ 
-		color: definitions.color.definition.defval, 
+		color: definitions.find(d => d.definition.id === PARAMETER_NAMES.COLOR)!.definition.defval, 
 		map: undefined, 
-		roughness: +definitions.roughness.definition.defval
+		roughness: +definitions.find(d => d.definition.id === PARAMETER_NAMES.ROUGHNESS)!.definition.defval
 	});
 
 	useDefineGenericParameters("mysession", !acceptRejectMode,
 		materialParameters,
 		async (values) => {
-			if ("colorParam" in values)
-				setMaterialProperties({ color: values["colorParam"] });
+			if (PARAMETER_NAMES.COLOR in values)
+				setMaterialProperties({ color: values[PARAMETER_NAMES.COLOR] });
 
-			if ("roughnessParam" in values)
-				setMaterialProperties({ roughness: values["roughnessParam"] });
+			if (PARAMETER_NAMES.ROUGHNESS in values)
+				setMaterialProperties({ roughness: values[PARAMETER_NAMES.ROUGHNESS] });
 
 			// due to the asynchronous nature of loading a map, we need to wait for the map to be loaded before we can set the material properties
 			// this also means that we resolve the promise only after the map has been loaded or if no map is specified
-			if ("mapParam" in values) {
-				const mapParam = values["mapParam"];
+			if (PARAMETER_NAMES.MAP in values) {
+				const mapParam = values[PARAMETER_NAMES.MAP];
 				if (mapParam !== "") {
 					try {
 						const map = await MaterialEngine.instance.loadMap(mapParam);

--- a/src/pages/ViewPage.tsx
+++ b/src/pages/ViewPage.tsx
@@ -1,5 +1,5 @@
 import { Tabs } from "@mantine/core";
-import { IMaterialStandardDataProperties, MaterialEngine, SESSION_SETTINGS_MODE } from "@shapediver/viewer";
+import { IMaterialStandardDataProperties, MaterialEngine, PARAMETER_TYPE, SESSION_SETTINGS_MODE } from "@shapediver/viewer";
 import { IconFileDownload, IconAdjustmentsHorizontal } from "@tabler/icons-react";
 import ViewportComponent from "components/shapediver/viewport/ViewportComponent";
 import React, { useEffect, useState } from "react";
@@ -17,7 +17,7 @@ import classes from "./ViewPage.module.css";
 import ParametersAndExportsAccordionTab from "../components/shapediver/ui/ParametersAndExportsAccordionTab";
 import { IGenericParameterDefinition } from "types/store/shapediverStoreParameters";
 import { useDefineGenericParameters } from "hooks/useDefineGenericParameters";
-import { useOutputMaterial } from "hooks/useOutputMaterial";
+import { MaterialType, useOutputMaterial } from "hooks/useOutputMaterial";
 
 /**
  * Function that creates the view page.
@@ -69,7 +69,7 @@ export default function ViewPage() {
 			definition: {
 				id: "colorParam",
 				name: "Custom color",
-				defval: "0xffffffff",
+				defval: "0x0d44f0ff",
 				type: "Color",
 				hidden: false
 			}
@@ -82,19 +82,38 @@ export default function ViewPage() {
 				type: "String",
 				hidden: false
 			}
+		},
+		roughness: {
+			definition: {
+				id: "roughnessParam",
+				name: "Custom roughness",
+				defval: "0",
+				type: PARAMETER_TYPE.FLOAT,
+				min: 0,
+				max: 1,
+				decimalplaces: 4,
+				hidden: false
+			}
 		}
 	};
 	
 	// define a generic parameter which influences a custom material definition
 	const [materialParameters] = useState<IGenericParameterDefinition[]>(Object.values(definitions));
 
-	const [materialProperties, setMaterialProperties] = useState<IMaterialStandardDataProperties>({ color: definitions.color.definition.defval, map: undefined });
+	const [materialProperties, setMaterialProperties] = useState<IMaterialStandardDataProperties>({ 
+		color: definitions.color.definition.defval, 
+		map: undefined, 
+		roughness: +definitions.roughness.definition.defval
+	});
 
 	useDefineGenericParameters("mysession", !acceptRejectMode,
 		materialParameters,
 		(values) => new Promise(resolve => {
 			if ("colorParam" in values)
 				setMaterialProperties({ color: values["colorParam"] });
+				
+			if ("roughnessParam" in values)
+				setMaterialProperties({ roughness: values["roughnessParam"] });
 
 			// due to the asynchronous nature of loading a map, we need to wait for the map to be loaded before we can set the material properties
 			// this also means that we resolve the promise only after the map has been loaded or if no map is specified
@@ -126,7 +145,7 @@ export default function ViewPage() {
 	const myParameterProps = useSessionPropsParameter("mysession");
 
 	// apply the custom material
-	useOutputMaterial(sessionId, outputNameOrId, materialProperties);
+	useOutputMaterial(sessionId, outputNameOrId, materialProperties, MaterialType.Unlit);
 	
 	/////	
 	// END - Example on how to apply a custom material to an output

--- a/src/pages/ViewPage.tsx
+++ b/src/pages/ViewPage.tsx
@@ -108,10 +108,10 @@ export default function ViewPage() {
 
 	useDefineGenericParameters("mysession", !acceptRejectMode,
 		materialParameters,
-		(values) => new Promise(resolve => {
+		async (values) => {
 			if ("colorParam" in values)
 				setMaterialProperties({ color: values["colorParam"] });
-				
+
 			if ("roughnessParam" in values)
 				setMaterialProperties({ roughness: values["roughnessParam"] });
 
@@ -119,28 +119,26 @@ export default function ViewPage() {
 			// this also means that we resolve the promise only after the map has been loaded or if no map is specified
 			if ("mapParam" in values) {
 				const mapParam = values["mapParam"];
-				if(mapParam !== "") {
-					MaterialEngine.instance.loadMap(mapParam).then(map => {
-						if(map) {
+				if (mapParam !== "") {
+					try {
+						const map = await MaterialEngine.instance.loadMap(mapParam);
+						if (map) {
 							setMaterialProperties({ map: map });
 						} else {
 							setMaterialProperties({ map: undefined });
 							console.warn(`Could not load map ${mapParam}`);
 						}
-					}).catch(e => {
+					} catch (e) {
 						setMaterialProperties({ map: undefined });
 						console.warn(`Could not load map ${mapParam}: ${e}`);
-					}).finally(() => {
-						resolve(values);
-					});
+					}
 				} else {
 					setMaterialProperties({ map: undefined });
-					resolve(values);
 				}
-			} else {
-				resolve(values);
 			}
-		})
+
+			return values;
+		}
 	);
 	const myParameterProps = useSessionPropsParameter("mysession");
 


### PR DESCRIPTION
https://shapediver.atlassian.net/browse/SS-6250

Please note that some of the code is in there for testing purposes (specifically, the MaterialType.UNLIT and the selection of default values).

What I changed:
- how the material data is accessed: in the previous way, there would be cases where this wouldn't have worked, as sometimes some geometries have materials and some don't
- async loading example for maps: please review this, I'm not sure if I should do it like that in react
- support for other materials: Currently on the ViewPage an unlit material is displayed, that's also why the roughness slider currently doesn't do anything. The type of material to be used can be specified as an input to the useOutputMaterial function. This then also allows the usage of this hook for gem materials etc.